### PR TITLE
Add logging support and fix bug with multiple WWW-Authenticate headers

### DIFF
--- a/requests_negotiate/__init__.py
+++ b/requests_negotiate/__init__.py
@@ -31,7 +31,7 @@ class HTTPNegotiateAuth(AuthBase):
     @property
     def username(self):
         logging.debug("Obtaining username from GSSAPI")
-        credential = gssapi.Credential()
+        credential = gssapi.Credential(usage=gssapi.C_INITIATE)
         logging.debug("Username={0}".format(credential.name))
         return str(credential.name)
 


### PR DESCRIPTION
I ran into issues authenticating to servers that offer both Basic and Negotiate authentication methods.  This was due to the WWW-Authenticate header failing to parse in this case.  The pull request fixes that issue as well as the following extra changes:
- Added logging support via the built-in `logging` module
- Improved compliance with PEP8 formatting standards
