### PR TITLE
Changed long unicode dashes to minus signs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Here's a trivial example:
     auth = requests_negotiate.HTTPNegotiateAuth()
     response = requests.get('https://example.org/', auth=auth)
 
-You'll need a valid Kerberos ticket — acquired using e.g. `kinit` — for this to work.
+You'll need a valid Kerberos ticket - acquired using e.g. `kinit` - for this to work.
 
 ### Options
 
 You can instantiate an ``HTTPNegotiateAuth`` with the following optional parameters:
 
-* ``service`` — A Kerberos principal is generally composed of a service name (e.g. 'HTTP') and a hostname, separated by a slash ('/'). This lets you override the default service of ``'HTTP'``.
-* ``service_name`` — Overrides the full service name (e.g. ``'HTTP/example.org'``)
-* ``negotiate_client_name`` — Explicitly specify which client principal to authenticate as. Particularly useful when you're using a credential cache collection.
-* ``preempt`` — Attempt Negotiate authentication before it is offered.
+* ``service`` - A Kerberos principal is generally composed of a service name (e.g. 'HTTP') and a hostname, separated by a slash ('/'). This lets you override the default service of ``'HTTP'``.
+* ``service_name`` - Overrides the full service name (e.g. ``'HTTP/example.org'``)
+* ``negotiate_client_name`` - Explicitly specify which client principal to authenticate as. Particularly useful when you're using a credential cache collection.
+* ``preempt`` - Attempt Negotiate authentication before it is offered.
 


### PR DESCRIPTION
The following line in setup.py:

    long_description=open('README.md').read(),

causes the following exceptions:

    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 515: ordinal not in range(128)

This patch removes unicode characters from README.md to address the problem.