### PR TITLE
Now performs an rDNS lookup against the machine we're connecting to.

### DIFF
--- a/requests_negotiate/__init__.py
+++ b/requests_negotiate/__init__.py
@@ -22,7 +22,6 @@ class HTTPNegotiateAuth(AuthBase):
                  negotiate_client_name=None):
         self.service = service
         self.service_name = service_name
-        self.contexts = {}
         self.negotiate_client_name = negotiate_client_name
 
     def __call__(self, request):
@@ -75,10 +74,7 @@ class HTTPNegotiateAuth(AuthBase):
 
         host = self.get_hostname(response)
         logger.debug("host={0}".format(host))
-        if host in self.contexts:
-            ctx = self.contexts[host]
-        else:
-            ctx = self.contexts[host] = self.get_context(host)
+        ctx = self.get_context(host)
 
         logger.debug("ctx={0}".format(ctx))
         in_token = base64.b64decode(challenges['negotiate'].encode('ascii')) \

--- a/requests_negotiate/__init__.py
+++ b/requests_negotiate/__init__.py
@@ -1,36 +1,31 @@
 import base64
-import re
+import socket
+
 import logging
 
 import gssapi
 from requests.auth import AuthBase
-from requests.compat import urlparse
 import www_authenticate
-
+from requests.packages.urllib3.connection import HTTPConnection
 
 logger = logging.getLogger(__name__)
 
 
 class HTTPNegotiateAuth(AuthBase):
     def __init__(self, service='HTTP', service_name=None,
-                 negotiate_client_name=None, preempt=False):
+                 negotiate_client_name=None):
         self.service = service
         self.service_name = service_name
         self.contexts = {}
-        self.preempt = preempt
         self.negotiate_client_name = negotiate_client_name
 
     def __call__(self, request):
-        host = urlparse(request.url).hostname
-        if self.preempt or host in self.contexts:
-            logger.debug("__call__(): pre-emptively sending authorization"
-                         "header")
-            self.contexts[host] = ctx = self.get_context(host)
-            token = ctx.step(None)
-            token_b64 = base64.b64encode(token).decode('utf-8')
-            request.headers['Authorization'] = 'Negotiate ' + token_b64
         request.register_hook('response', self.handle_401)
         return request
+
+    def get_hostname(self, response):
+        assert isinstance(response.raw._connection, HTTPConnection)
+        return socket.gethostbyaddr(response.raw._connection.sock.getpeername()[0])[0]
 
     @property
     def username(self):
@@ -67,7 +62,7 @@ class HTTPNegotiateAuth(AuthBase):
             logger.debug("Giving up on negotiate auth")
             return response
 
-        host = urlparse(response.url).hostname
+        host = self.get_hostname(response)
         logger.debug("host={0}".format(host))
         if host in self.contexts:
             ctx = self.contexts[host]


### PR DESCRIPTION
Previously, if a hostname had multiple IP addresses, there was a not
insignificant chance that the Kerberos library would do an rDNS lookup
and find a hostname that didn't match what we were connecting to.

We now do our own rDNS lookup against our socket peer.

This is modelled on https://github.com/cannatag/ldap3/pull/89, which
fixes support for DNS round-robins in the ldap3 library.